### PR TITLE
adds babel  stage-0 preset needed for object rest spread transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015","react"]
+  "presets": ["es2015","react", "stage-0"]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/jrans/React-Webpack-Set-Up#readme",
   "dependencies": {
+    "babel-preset-stage-0": "^6.1.2",
     "react": "^0.14.1",
     "react-dom": "^0.14.1"
   },

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     module: {
       loaders: [
-        { test: /\.js$/, exclude: /node_modules/, loaders: ['babel', 'jsx']},
+        { test: /\.js$/, exclude: /node_modules/, loaders: ['babel']},
         { test: /\.css$/, loader: 'style!css'}
       ]
     },


### PR DESCRIPTION
The object spread transform didn't work so I added the stage-0 present to the  package.json and .babelrc and also modified the production config to delete the 'jsx' loader.  :smile_cat: 
